### PR TITLE
make df_write return the DataFrame so it can be used in Pipes

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -158,11 +158,10 @@ function df_write(file::AbstractString, df::DataFrame; subformat::Union{Nothing,
         compress(file, subfile) do f
             _df_write(f, subformat, df, dictencode=dictencode)
         end
-
-        return
+	else
+		_df_write(file, format, df, dictencode=dictencode)
     end
-
-    _df_write(file, format, df, dictencode=dictencode)
+	df
 end
 
 


### PR DESCRIPTION
Currently df_write returns nothing, so if you want to create, serialize it and then return it, you have to assign it

```
function df(filename, params)
    df = data(params) |> DataFrame
    df_write(filename, df)
    return df
end
```

whereas with this simple change one can do

`df(filename, params) = @pipe data(params) |> DataFrame |> df_write(filename, _)`

